### PR TITLE
Add changes needed to build on the Jetson Nano

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.4)
 
-cmake_policy(SET CMP0074 NEW)
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
+    cmake_policy(SET CMP0074 NEW)
+endif()
 
 project(oxts-sdk LANGUAGES CXX C)
 
@@ -12,9 +14,9 @@ add_definitions(-DOXTS_SDK_VERSION_PATCH=${oxts-sdk_VERSION_PATCH})
 
 # Building and installation options
 option(OXTS_SDK_BUILD_DOCS "Build SDK documentation." OFF)
-option(OXTS_SDK_BUILD_TESTS "Enable unit test targets." ON) 
-option(OXTS_SDK_BUILD_EXAMPLES "Enable examples targets." ON) 
-option(OXTS_SDK_BUILD_PYTHON "Build SDK Python wrapper." OFF) 
+option(OXTS_SDK_BUILD_TESTS "Enable unit test targets." ON)
+option(OXTS_SDK_BUILD_EXAMPLES "Enable examples targets." ON)
+option(OXTS_SDK_BUILD_PYTHON "Build SDK Python wrapper." OFF)
 option(OXTS_SDK_DISABLE_BOOST "Disable Boost library when building." OFF)
 # Used for cpp linting by clang-tidy
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -49,15 +51,22 @@ if (OXTS_SDK_BUILD_TESTS)
 endif()
 
 if (OXTS_SDK_BUILD_PYTHON)
+    find_package(Boost COMPONENTS system thread regex)
     add_subdirectory(oxts-sdk-py/pybind11)
-    pybind11_add_module(oxts_sdk oxts-sdk-py/gal-py-bindings.cpp 
+    pybind11_add_module(oxts_sdk oxts-sdk-py/gal-py-bindings.cpp
                                  oxts-sdk-gal-cpp/src/gal-cpp/gad.cpp
                                  oxts-sdk-gal-cpp/src/gal-cpp/gad_handler.cpp
                                  oxts-sdk-gal-c/src/gad_encode_bin.c
                                  oxts-sdk-gal-c/src/gad_encode_csv.c
                                  oxts-sdk-core/src/BasicCasts.c
                                  oxts-sdk-core/src/ccomtx.cpp
-    )
+				 )
+    # P. Rodrigues 2023-07-27 On the Jetson Nano, we have an old
+    # boost, which needs this link line. Newer boost versions
+    # evidently don't require it.
+    if ("${Boost_VERSION}" EQUAL "106501")
+        target_link_libraries(oxts_sdk PUBLIC ${Boost_LIBRARIES})
+    endif()
 
     include_directories(oxts-sdk-gal-cpp/include)
     include_directories(oxts-sdk-gal-c/include)

--- a/examples/gal/CMakeLists.txt
+++ b/examples/gal/CMakeLists.txt
@@ -2,8 +2,11 @@ cmake_minimum_required(VERSION 3.1)
 
 # C++ Standard version. Minimum supported is C++11.
 set(CMAKE_CXX_STANDARD 11)
-# Explicitly set policy for _DIR behaviour
-cmake_policy(SET CMP0074 NEW)
+
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
+    # Explicitly set policy for _DIR behaviour
+    cmake_policy(SET CMP0074 NEW)
+endif()
 
 project(oxts-sdk-examples-gal VERSION 0.1.0)
 

--- a/oxts-sdk-gal-cpp/CMakeLists.txt
+++ b/oxts-sdk-gal-cpp/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 
-cmake_policy(SET CMP0074 NEW)
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
+    cmake_policy(SET CMP0074 NEW)
+endif()
 
 
 # define library version 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,8 +2,11 @@ cmake_minimum_required(VERSION 3.1)
 
 # C++ Standard version. Minimum supported is C++11.
 set(CMAKE_CXX_STANDARD 11)
-# Explicitly set policy for _DIR behaviour
-cmake_policy(SET CMP0074 NEW)
+
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
+    # Explicitly set policy for _DIR behaviour
+    cmake_policy(SET CMP0074 NEW)
+endif()
 
 project(oxts-sdk-examples-gal VERSION 0.1.0)
 


### PR DESCRIPTION
On the Jetson Nano, the cmake version is 3.10.2, which doesn't have CMP0074 (introduced in 3.12). The Jetson Nano also has boost 1.65.01, which appears to need an extra link line compared to newer versions. Without this extra link, I get an "undefined symbol" error after `import oxts_sdk`.