### PR TITLE
Update documentation of `Gad::SetTimeLatency()`

### DIFF
--- a/oxts-sdk-gal-cpp/include/oxts/gal-cpp/gad.hpp
+++ b/oxts-sdk-gal-cpp/include/oxts/gal-cpp/gad.hpp
@@ -206,9 +206,9 @@ namespace OxTS
 		 * of the time taken for the packet to travel from the aiding source to the
 		 * INS. Upon arrival the INS will timestamp the data, adjusting for the
 		 * latency.
-		 * @param ns Latency estimate in (nanoseconds).
+		 * @param s Latency estimate in seconds.
 		 */
-		void SetTimeLatency(double ns);
+		void SetTimeLatency(double s);
 		/** Get latency estimate.   */
 		double GetTimeLatency() const;
 		/** Set the timestamp as UTC time encoded as the number of seconds from the UNIX epoch.

--- a/oxts-sdk-gal-cpp/src/gal-cpp/gad.cpp
+++ b/oxts-sdk-gal-cpp/src/gal-cpp/gad.cpp
@@ -302,12 +302,12 @@ namespace OxTS
 	}
 	double Gad::GetTimePpsRelative() const { return time.GetValZ(); }
 	// Latency
-	void   Gad::SetTimeLatency(double ns)
+	void   Gad::SetTimeLatency(double s)
 	{
 		SetTimeValid(true);
 		time.SetMode(0);
 		time.SetValType(TIME_SYS::TIME_EST_LATENCY);
-		time.SetVal(0.0, ns, 0.0);
+		time.SetVal(0.0, s, 0.0);
 	}
 	double Gad::GetTimeLatency() const { return time.GetValY(); }
 	// UTC - Unix


### PR DESCRIPTION
The doxygen comments for `SetTimeLatency()` say that the units are nanoseconds, but they're actually seconds. This fixes that.