### PR TITLE
Removed cmake_policy(CMP0074 NEW) specifiers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-cmake_policy(SET CMP0074 NEW)
+
 
 project(oxts-sdk VERSION 2.0.1 LANGUAGES CXX C)
 

--- a/examples/gal/CMakeLists.txt
+++ b/examples/gal/CMakeLists.txt
@@ -2,10 +2,6 @@ cmake_minimum_required(VERSION 3.10)
 
 # C++ Standard version. Minimum supported is C++11.
 set(CMAKE_CXX_STANDARD 11)
-# Explicitly set policy for _DIR behaviour
-cmake_policy(SET CMP0074 NEW)
-
-
 
 project(oxts-sdk-examples-gal VERSION 0.1.0)
 

--- a/oxts-sdk-gal-cpp/CMakeLists.txt
+++ b/oxts-sdk-gal-cpp/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
 
-cmake_policy(SET CMP0074 NEW)
-
 
 # define library version 
 set(OXTS_SDK_GAL_VERSION_MAJOR 0 CACHE STRING "major version" FORCE)


### PR DESCRIPTION
 policy did not exist in cmake 3.10 and causes errors by not being recognised. Does not appear to be required.