### PR TITLE
Changed OXTS_* macro checks to #if instead of #ifdef to avoid clashes

### DIFF
--- a/oxts-sdk-gal-c/include/oxts/gal-c/Lib_Detect.h
+++ b/oxts-sdk-gal-c/include/oxts/gal-c/Lib_Detect.h
@@ -25,48 +25,48 @@
 // OXTS_CC: OXTS_CC_MSVC OXTS_CC_MINGW OXTS_CC_CYGWIN OXTS_CC_GCC OXTS_CC_QCC OXTS_CC_BORLAND OXTS_CC_TI
 
 #ifdef _MSC_VER
-#if (defined(OXTS_CC_BORLAND) || defined(OXTS_CC_MINGW) || defined(OXTS_CC_CYGWIN) || defined(OXTS_CC_QCC) || defined(OXTS_CC_TI) || defined(OXTS_CC_GCC))
+#if ((OXTS_CC_BORLAND) || (OXTS_CC_MINGW) || (OXTS_CC_CYGWIN) || (OXTS_CC_QCC) || (OXTS_CC_TI) || (OXTS_CC_GCC))
 #error "Detected MSVC but you say something else"
 #endif
-#define OXTS_CC_MSVC
+#define OXTS_CC_MSVC (1)
 #elif __BORLANDC__
-#if (defined(OXTS_CC_MSVC) || defined(OXTS_CC_MINGW) || defined(OXTS_CC_CYGWIN) || defined(OXTS_CC_QCC) || defined(OXTS_CC_TI) || defined(OXTS_CC_GCC))
+#if ((OXTS_CC_MSVC) || (OXTS_CC_MINGW) || (OXTS_CC_CYGWIN) || (OXTS_CC_QCC) || (OXTS_CC_TI) || (OXTS_CC_GCC))
 #error "Detected BORLAND but you say something else"
 #endif
-#define OXTS_CC_BORLAND
+#define OXTS_CC_BORLAND (1)
 #elif (__MINGW32__ || __MINGW64__)
-#if (defined(OXTS_CC_MSVC) || defined(OXTS_CC_BORLAND) || defined(OXTS_CC_CYGWIN) || defined(OXTS_CC_QCC) || defined(OXTS_CC_TI) || defined(OXTS_CC_GCC))
+#if ((OXTS_CC_MSVC) || (OXTS_CC_BORLAND) || (OXTS_CC_CYGWIN) || (OXTS_CC_QCC) || (OXTS_CC_TI) || (OXTS_CC_GCC))
 #error "Detected MINGW but you say something else"
 #endif
-#define OXTS_CC_MINGW
+#define OXTS_CC_MINGW (1)
 #elif __CYGWIN32__
-#if (defined(OXTS_CC_MSVC) || defined(OXTS_CC_BORLAND) || defined(OXTS_CC_MINGW) || defined(OXTS_CC_QCC) || defined(OXTS_CC_TI) || defined(OXTS_CC_GCC))
+#if ((OXTS_CC_MSVC) || (OXTS_CC_BORLAND) || (OXTS_CC_MINGW) || (OXTS_CC_QCC) || (OXTS_CC_TI) || (OXTS_CC_GCC))
 #error "Detected CYGWIN but you say something else"
 #endif
-#define OXTS_CC_CYGWIN
+#define OXTS_CC_CYGWIN (1)
 #elif defined(__QNX__)
-#if (defined(OXTS_CC_MSVC) || defined(OXTS_CC_BORLAND) || defined(OXTS_CC_MINGW) || defined(OXTS_CC_CYGWIN) || defined(OXTS_CC_TI) || defined(OXTS_CC_GCC))
+#if ((OXTS_CC_MSVC) || (OXTS_CC_BORLAND) || (OXTS_CC_MINGW) || (OXTS_CC_CYGWIN) || (OXTS_CC_TI) || (OXTS_CC_GCC))
 #error "Detected QCC but you say something else"
 #endif
-#define OXTS_CC_QCC
+#define OXTS_CC_QCC (1)
 #elif defined(__TI_COMPILER_VERSION__)
-#if (defined(OXTS_CC_MSVC) || defined(OXTS_CC_BORLAND) || defined(OXTS_CC_MINGW) || defined(OXTS_CC_CYGWIN) || defined(OXTS_CC_QCC) || defined(OXTS_CC_GCC))
+#if ((OXTS_CC_MSVC) || (OXTS_CC_BORLAND) || (OXTS_CC_MINGW) || (OXTS_CC_CYGWIN) || (OXTS_CC_QCC) || (OXTS_CC_GCC))
 #error "Detected TI but you say something else"
 #endif
-#define OXTS_CC_TI
+#define OXTS_CC_TI (1)
 #elif __GNUC__
-#if (defined(OXTS_CC_MSVC) || defined(OXTS_CC_BORLAND) || defined(OXTS_CC_MINGW) || defined(OXTS_CC_CYGWIN) || defined(OXTS_CC_QCC) || defined(OXTS_CC_TI))
+#if ((OXTS_CC_MSVC) || (OXTS_CC_BORLAND) || (OXTS_CC_MINGW) || (OXTS_CC_CYGWIN) || (OXTS_CC_QCC) || (OXTS_CC_TI))
 #error "Detected GCC but you say something else"
 #endif
-#define OXTS_CC_GCC
+#define OXTS_CC_GCC (1)
 #else
 #error "Compiler not understood"
 #endif
 
 
-#ifdef OXTS_CC_MSVC
+#if (OXTS_CC_MSVC)
 #ifdef __CLR_VER
-#define OXTS_CC_MSVC_CLR
+#define OXTS_CC_MSVC_CLR (1)
 #endif
 #endif
 
@@ -75,27 +75,27 @@
 // OXTS_OS: OXTS_OS_WINDOWS OXTS_OS_QNX OXTS_OS_TI OXTS_OS_LINUX
 
 #if defined(WIN32) || defined(_WIN32)
-		#if (defined(OXTS_OS_QNX) || defined(OXTS_OS_TI) || defined(OXTS_OS_LINUX) || defined(OXTS_OS_XDEV))
+		#if ((OXTS_OS_QNX) || (OXTS_OS_TI) || (OXTS_OS_LINUX) || (OXTS_OS_XDEV))
 		#error "Detected OXTS_OS_WINDOWS but you say something else"
 		#endif
 	#define OXTS_OS_WINDOWS /*PRQA S 1534 # Macro is intended for external consumption. */
 #elif defined(__QNX__)
-		#if (defined(OXTS_OS_WINDOWS) || defined(OXTS_OS_TI) || defined(OXTS_OS_LINUX) || defined(OXTS_OS_XDEV))
+		#if ((OXTS_OS_WINDOWS) || (OXTS_OS_TI) || (OXTS_OS_LINUX) || (OXTS_OS_XDEV))
 		#error "Detected OXTS_OS_QNX but you say something else"
 		#endif
 	#define OXTS_OS_QNX
 #elif defined(__TI_COMPILER_VERSION__)
-		#if (defined(OXTS_OS_WINDOWS) || defined(OXTS_OS_QNX) || defined(OXTS_OS_LINUX) || defined(OXTS_OS_XDEV))
+		#if ((OXTS_OS_WINDOWS) || (OXTS_OS_QNX) || (OXTS_OS_LINUX) || (OXTS_OS_XDEV))
 		#error "Detected OXTS_OS_TI but you say something else"
 		#endif
 	#define OXTS_OS_TI
 #elif defined(xDev)
-		#if (defined(OXTS_OS_WINDOWS) || defined(OXTS_OS_QNX) || defined(OXTS_OS_LINUX) || defined(OXTS_OS_XDEV))
+		#if ((OXTS_OS_WINDOWS) || (OXTS_OS_QNX) || (OXTS_OS_LINUX) || (OXTS_OS_XDEV))
 		#error "Detected OXTS_OS_TI but you say something else"
 		#endif
 	#define OXTS_OS_XDEV
 #else
-#if (defined(OXTS_OS_WINDOWS) || defined(OXTS_OS_QNX) || defined(OXTS_OS_TI) || defined(OXTS_OS_XDEV))
+#if ((OXTS_OS_WINDOWS) || (OXTS_OS_QNX) || (OXTS_OS_TI) || (OXTS_OS_XDEV))
 #error "Detected OXTS_OS_LINUX but you say something else"
 #endif
 #define OXTS_OS_LINUX

--- a/oxts-sdk-gal-cpp/include/oxts/gal-cpp/Lib_Detect.hpp
+++ b/oxts-sdk-gal-cpp/include/oxts/gal-cpp/Lib_Detect.hpp
@@ -25,37 +25,37 @@
 // OXTS_CC: OXTS_CC_MSVC OXTS_CC_MINGW OXTS_CC_CYGWIN OXTS_CC_GCC OXTS_CC_QCC OXTS_CC_BORLAND OXTS_CC_TI
 
 #if (_MSC_VER)
-#if (defined(OXTS_CC_BORLAND) || defined(OXTS_CC_MINGW) || defined(OXTS_CC_CYGWIN) || defined(OXTS_CC_QCC) || defined(OXTS_CC_TI) || defined(OXTS_CC_GCC))
+#if ((OXTS_CC_BORLAND) || (OXTS_CC_MINGW) || (OXTS_CC_CYGWIN) || (OXTS_CC_QCC) || (OXTS_CC_TI) || (OXTS_CC_GCC))
 #error "Detected MSVC but you say something else"
 #endif
-#define OXTS_CC_MSVC
+#define OXTS_CC_MSVC (1)
 #elif __BORLANDC__
-#if (defined(OXTS_CC_MSVC) || defined(OXTS_CC_MINGW) || defined(OXTS_CC_CYGWIN) || defined(OXTS_CC_QCC) || defined(OXTS_CC_TI) || defined(OXTS_CC_GCC))
+#if ((OXTS_CC_MSVC) || (OXTS_CC_MINGW) || (OXTS_CC_CYGWIN) || (OXTS_CC_QCC) || (OXTS_CC_TI) || (OXTS_CC_GCC))
 #error "Detected BORLAND but you say something else"
 #endif
 #define OXTS_CC_BORLAND
 #elif (__MINGW32__ || __MINGW64__)
-#if (defined(OXTS_CC_MSVC) || defined(OXTS_CC_BORLAND) || defined(OXTS_CC_CYGWIN) || defined(OXTS_CC_QCC) || defined(OXTS_CC_TI) || defined(OXTS_CC_GCC))
+#if ((OXTS_CC_MSVC) || (OXTS_CC_BORLAND) || (OXTS_CC_CYGWIN) || (OXTS_CC_QCC) || (OXTS_CC_TI) || (OXTS_CC_GCC))
 #error "Detected MINGW but you say something else"
 #endif
 #define OXTS_CC_MINGW
 #elif __CYGWIN32__
-#if (defined(OXTS_CC_MSVC) || defined(OXTS_CC_BORLAND) || defined(OXTS_CC_MINGW) || defined(OXTS_CC_QCC) || defined(OXTS_CC_TI) || defined(OXTS_CC_GCC))
+#if ((OXTS_CC_MSVC) || (OXTS_CC_BORLAND) || (OXTS_CC_MINGW) || (OXTS_CC_QCC) || (OXTS_CC_TI) || (OXTS_CC_GCC))
 #error "Detected CYGWIN but you say something else"
 #endif
 #define OXTS_CC_CYGWIN
 #elif defined(__QNX__)
-#if (defined(OXTS_CC_MSVC) || defined(OXTS_CC_BORLAND) || defined(OXTS_CC_MINGW) || defined(OXTS_CC_CYGWIN) || defined(OXTS_CC_TI) || defined(OXTS_CC_GCC))
+#if ((OXTS_CC_MSVC) || (OXTS_CC_BORLAND) || (OXTS_CC_MINGW) || (OXTS_CC_CYGWIN) || (OXTS_CC_TI) || (OXTS_CC_GCC))
 #error "Detected QCC but you say something else"
 #endif
 #define OXTS_CC_QCC
 #elif defined(__TI_COMPILER_VERSION__)
-#if (defined(OXTS_CC_MSVC) || defined(OXTS_CC_BORLAND) || defined(OXTS_CC_MINGW) || defined(OXTS_CC_CYGWIN) || defined(OXTS_CC_QCC) || defined(OXTS_CC_GCC))
+#if ((OXTS_CC_MSVC) || (OXTS_CC_BORLAND) || (OXTS_CC_MINGW) || (OXTS_CC_CYGWIN) || (OXTS_CC_QCC) || (OXTS_CC_GCC))
 #error "Detected TI but you say something else"
 #endif
 #define OXTS_CC_TI
 #elif __GNUC__
-#if (defined(OXTS_CC_MSVC) || defined(OXTS_CC_BORLAND) || defined(OXTS_CC_MINGW) || defined(OXTS_CC_CYGWIN) || defined(OXTS_CC_QCC) || defined(OXTS_CC_TI))
+#if ((OXTS_CC_MSVC) || (OXTS_CC_BORLAND) || (OXTS_CC_MINGW) || (OXTS_CC_CYGWIN) || (OXTS_CC_QCC) || (OXTS_CC_TI))
 #error "Detected GCC but you say something else"
 #endif
 #define OXTS_CC_GCC
@@ -75,30 +75,30 @@
 // OXTS_OS: OXTS_OS_WINDOWS OXTS_OS_QNX OXTS_OS_TI OXTS_OS_LINUX
 
 #if defined(WIN32) || defined(_WIN32)
-		#if (defined(OXTS_OS_QNX) || defined(OXTS_OS_TI) || defined(OXTS_OS_LINUX) || defined(OXTS_OS_XDEV))
+		#if ((OXTS_OS_QNX) || (OXTS_OS_TI) || (OXTS_OS_LINUX) || (OXTS_OS_XDEV))
 		#error "Detected OXTS_OS_WINDOWS but you say something else"
 		#endif
-	#define OXTS_OS_WINDOWS
+	#define OXTS_OS_WINDOWS (1)
 #elif defined(__QNX__)
-		#if (defined(OXTS_OS_WINDOWS) || defined(OXTS_OS_TI) || defined(OXTS_OS_LINUX) || defined(OXTS_OS_XDEV))
+		#if ((OXTS_OS_WINDOWS) || (OXTS_OS_TI) || (OXTS_OS_LINUX) || (OXTS_OS_XDEV))
 		#error "Detected OXTS_OS_QNX but you say something else"
 		#endif
-	#define OXTS_OS_QNX
+	#define OXTS_OS_QNX (1)
 #elif defined(__TI_COMPILER_VERSION__)
-		#if (defined(OXTS_OS_WINDOWS) || defined(OXTS_OS_QNX) || defined(OXTS_OS_LINUX) || defined(OXTS_OS_XDEV))
+		#if ((OXTS_OS_WINDOWS) || (OXTS_OS_QNX) || (OXTS_OS_LINUX) || (OXTS_OS_XDEV))
 		#error "Detected OXTS_OS_TI but you say something else"
 		#endif
-	#define OXTS_OS_TI
+	#define OXTS_OS_TI (1)
 #elif defined(xDev)
-		#if (defined(OXTS_OS_WINDOWS) || defined(OXTS_OS_QNX) || defined(OXTS_OS_LINUX) || defined(OXTS_OS_XDEV))
+		#if ((OXTS_OS_WINDOWS) || (OXTS_OS_QNX) || (OXTS_OS_LINUX) || (OXTS_OS_XDEV))
 		#error "Detected OXTS_OS_TI but you say something else"
 		#endif
-	#define OXTS_OS_XDEV
+	#define OXTS_OS_XDEV (1)
 #else
-#if (defined(OXTS_OS_WINDOWS) || defined(OXTS_OS_QNX) || defined(OXTS_OS_TI) || defined(OXTS_OS_XDEV))
+#if ((OXTS_OS_WINDOWS) || (OXTS_OS_QNX) || (OXTS_OS_TI) || (OXTS_OS_XDEV))
 #error "Detected OXTS_OS_LINUX but you say something else"
 #endif
-#define OXTS_OS_LINUX
+#define OXTS_OS_LINUX (1)
 #endif
 
 

--- a/oxts-sdk-gal-cpp/include/oxts/gal-cpp/oxts_sockets.hpp
+++ b/oxts-sdk-gal-cpp/include/oxts/gal-cpp/oxts_sockets.hpp
@@ -4,7 +4,7 @@
 
 #include "oxts/gal-cpp/Lib_Detect.hpp"
 
-#ifdef OXTS_OS_WINDOWS
+#if (OXTS_OS_WINDOWS)
 #define WIN32_LEAN_AND_MEAN /*PRQA S 1534 # Used by windows.h */
 #include <windows.h>
 #include <process.h>
@@ -22,7 +22,7 @@
 #include <cstdint>
 #include "oxts/gal-cpp/oxts_arrays.hpp"
 
-#ifndef OXTS_CC_MSVC
+#if !(OXTS_CC_MSVC)
 typedef sa_family_t ADDRESS_FAMILY;
 #endif
 
@@ -60,7 +60,7 @@ namespace OxTS
 			bool     m_broadcast;
 			bool     m_is_good;
 			bool     m_active;
-#ifdef OXTS_OS_WINDOWS
+#if (OXTS_OS_WINDOWS)
 			WSADATA  m_wsaData;
 			UINT_PTR m_handle;
 #else

--- a/oxts-sdk-gal-cpp/include/oxts/gal-cpp/udp_server_client.hpp
+++ b/oxts-sdk-gal-cpp/include/oxts/gal-cpp/udp_server_client.hpp
@@ -15,7 +15,7 @@
 #include <iostream>
 #include <string>
 
-#ifndef OXTS_CC_MSVC
+#if !(OXTS_CC_MSVC)
 #include <arpa/inet.h>
 #endif
 

--- a/oxts-sdk-gal-cpp/src/gal-cpp/oxts_sockets.cpp
+++ b/oxts-sdk-gal-cpp/src/gal-cpp/oxts_sockets.cpp
@@ -17,7 +17,7 @@ namespace OxTS
 		bool SocketSystem::startup()
 		{
 			bool success = true;
-#ifdef OXTS_OS_WINDOWS
+#if (OXTS_OS_WINDOWS)
 			if (m_ref_count == 0UL)
 			{
 				WSADATA WsaData;
@@ -48,7 +48,7 @@ namespace OxTS
 			{
 				m_ref_count--;
 
-#ifdef OXTS_OS_WINDOWS
+#if (OXTS_OS_WINDOWS)
 				if (m_ref_count == 0UL)
 				{
 					if (WSACleanup() != 0)
@@ -76,7 +76,7 @@ namespace OxTS
 			:
 			m_broadcast(broadcast_),
 			m_active(false),
-#ifdef OXTS_OS_WINDOWS
+#if (OXTS_OS_WINDOWS)
 			m_wsaData(),
 			m_handle(0UL),
 #else
@@ -161,7 +161,7 @@ namespace OxTS
 				if (success)
 				{
 					sockaddr_in address;
-#ifdef OXTS_CC_MSVC
+#if (OXTS_CC_MSVC)
 					std::int32_t len = static_cast<int32_t>(sizeof(sockaddr_in));
 					if ((getsockname(m_handle, reinterpret_cast<struct sockaddr*>(&address), &len) != 0) || (len == 0))
 #else
@@ -201,7 +201,7 @@ namespace OxTS
 			}
 			else
 			{
-#ifdef OXTS_OS_WINDOWS
+#if (OXTS_OS_WINDOWS)
 				if (closesocket(m_handle) == SOCKET_ERROR)
 				{
 					m_is_good = false;


### PR DESCRIPTION
Largely this isn't going to be an issue for external users (or even a noticeable change) as they do not use our macros themselves, but it caused clashes for myself.